### PR TITLE
Add support for sending OEM commands

### DIFF
--- a/FastBootCommands.cs
+++ b/FastBootCommands.cs
@@ -455,16 +455,28 @@ namespace FastBoot
         public static bool SendOEMCommand(this FastBootTransport fastBootTransport, string command, out string commandResponse)
         {
             FastBootStatus status;
-            string response;
+            string response = "";
 
             try
             {
                 (FastBootStatus status, string response, byte[] rawResponse)[] responses = fastBootTransport.SendCommand($"oem {command}");
-                (status, response, byte[] _) = responses.Last();
+                (status, string _, byte[] _) = responses.Last();
+                foreach((FastBootStatus status, string response, byte[] rawResponse) responseLine in responses) 
+                {
+                    if (responseLine.response.EndsWith("\n") || responseLine.response.EndsWith("\r\n"))
+                    {
+                        response += responseLine.response;
+                    }
+                    else
+                    {
+                        response += responseLine.response + "\n";
+                    }
+                }
+                response = response.Trim(); // Trim any unnecessary whitespaces.
             }
             catch
             {
-                commandResponse = "";
+                commandResponse = response;
                 return false;
             }
 

--- a/FastBootCommands.cs
+++ b/FastBootCommands.cs
@@ -451,5 +451,32 @@ namespace FastBoot
 
             return true;
         }
+
+        public static bool SendOEMCommand(this FastBootTransport fastBootTransport, string command, out string commandResponse)
+        {
+            FastBootStatus status;
+            string response;
+
+            try
+            {
+                (FastBootStatus status, string response, byte[] rawResponse)[] responses = fastBootTransport.SendCommand($"oem {command}");
+                (status, response, byte[] _) = responses.Last();
+            }
+            catch
+            {
+                commandResponse = "";
+                return false;
+            }
+
+            if (status != FastBootStatus.OKAY)
+            {
+                commandResponse = response; // The OEM Command may fail with a specific response that the end user may want to see, still assign a response.
+                return false;
+            }
+
+            commandResponse = response;
+
+            return true;
+        }
     }
 }


### PR DESCRIPTION
This change has been tested on 3 Devices,

Samsung Galaxy S4 (Using LK2ND):
"help" will return bool True as it is a successful command run and will output the following as shown in the picture

![image](https://github.com/WOA-Project/FastBoot/assets/78730004/a63607d3-fbc8-4dc3-b102-7c9530c67629)

Xiaomi POCO X3 Pro (Stock Bootloader):
"unlock" will return bool False as its an unsuccessful command run and will output the following as shown in the picture

![image](https://github.com/WOA-Project/FastBoot/assets/78730004/39e4ae2d-b7b3-4804-b82e-ace3ec94686d)

HTC Desire (BOS Descriptor check bypassed in registry, Revolutionary S-OFF):
"unlock" will return bool True as any command is technically a successful command and will output the following as shown in the picture

![image](https://github.com/WOA-Project/FastBoot/assets/78730004/57f76177-5583-4df9-bd1f-cb2b9c74b51a)

